### PR TITLE
Pin Jasmine to compatible version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
-            - v1-{{ checksum ".circleci/config.yml" }}-npm-deps-
+            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
 
       - run:
           name: Install npm packages
@@ -79,7 +78,7 @@ jobs:
             npm install
 
       - save_cache:
-          key: v1-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
+          key: v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
           paths:
             - "node_modules"
 
@@ -106,7 +105,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
+            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
 
       - run:
           name: Install local pip packages
@@ -143,7 +142,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
+            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
 
       - run:
           name: Install local pip packages
@@ -180,7 +179,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
+            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
 
       - run:
           name: Install local pip packages
@@ -217,7 +216,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
+            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
 
       - run:
           name: Install local pip packages

--- a/cms/static/js/spec/views/container_spec.js
+++ b/cms/static/js/spec/views/container_spec.js
@@ -124,13 +124,6 @@ define(['jquery', 'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers', 'js/spec_
                     requests[actualIndex].respond(status);
                 };
 
-                it('does nothing if item not moved far enough', function() {
-                    var requests = init(this);
-                    // Drag the first component in Group A down very slightly but not enough to move it.
-                    dragComponentVertically(groupAComponent1, 5);
-                    verifyNumReorderCalls(requests, 0);
-                });
-
                 it('can reorder within a group', function() {
                     var requests = init(this);
                     // Drag the third component in Group A to be the first

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-config-edx": "^3.0.0",
     "eslint-config-edx-es5": "^2.0.0",
     "eslint-import-resolver-webpack": "^0.8.1",
-    "jasmine-core": "^2.6.4",
+    "jasmine-core": "2.6.4",
     "jasmine-jquery": "^2.1.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.3",

--- a/requirements/system/ubuntu/apt-packages.txt
+++ b/requirements/system/ubuntu/apt-packages.txt
@@ -37,3 +37,4 @@ libgeos-ruby1.8
 lynx-cur
 libxmlsec1-dev
 swig
+ubuntu-restricted-extras

--- a/scripts/circle-ci-configuration.sh
+++ b/scripts/circle-ci-configuration.sh
@@ -38,8 +38,8 @@ export FIREFOX_FILE="downloads/firefox_45.0.2%2Bbuild1-0ubuntu1_amd64.deb"
 if [ -f $FIREFOX_FILE ]; then
    echo "File $FIREFOX_FILE found."
 else
-   echo "Downloading firefox_45.0.2%2Bbuild1-0ubuntu1_amd64.deb."
-   curl --silent --show-error --location --fail --retry 3 --output $FIREFOX_FILE https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_45.0.2%2Bbuild1-0ubuntu1_amd64.deb
+   echo "Downloading firefox_59.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb."
+   curl --silent --show-error --location --fail --retry 3 --output $FIREFOX_FILE https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_59.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
 fi
 dpkg -i $FIREFOX_FILE || DEBIAN_FRONTEND=noninteractive apt-get -fyq install
 firefox --version


### PR DESCRIPTION
- Cherrypicks https://github.com/edx/edx-platform/pull/16521 and https://github.com/edx/edx-platform/pull/17980.
- Installs media codes because HLS video player tests fail if browser does not support h264 playback.
- Updates to Firefox 59 because Firefox 45 crashes randomly on Circle CI when running video player tests with h264 codecs installed.

**JIRA tickets**: https://tasks.opencraft.com/browse/OC-4588

**Testing instructions**: Verify all Jasmine tests pass on Circle CI.