### PR TITLE
Fix test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,42 @@ jobs:
             source /tmp/workspace/venv/bin/activate
             paver test_system -s lms --with-flaky --processes=1 --cov-args="-p" --with-xunitmp
 
+  lms_unit_tests_no_env_var:
+    docker:
+      - image: edxops/xenial-common:hawthorn.master
+    environment:
+      - NO_PREREQ_INSTALL: "true"
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-{{ checksum ".circleci/config.yml" }}-configuration-{{ checksum "scripts/circle-ci-configuration.sh" }}
+
+      - run:
+          name: Install deb packages
+          command: |
+            ./scripts/circle-ci-configuration.sh
+
+      - attach_workspace:
+          at: /tmp/workspace
+
+      - restore_cache:
+          keys:
+            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
+
+      - run:
+          name: Install local pip packages
+          command: |
+            source /tmp/workspace/venv/bin/activate
+            pip install -r requirements/edx/local.txt
+
+      - run:
+          name: Run tests
+          command: |
+            source /tmp/workspace/venv/bin/activate
+            paver test_system -s lms --with-flaky --processes=1 --cov-args="-p" --with-xunitmp
+
   cms_unit_tests:
     docker:
       - image: edxops/xenial-common:hawthorn.master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       - image: edxops/xenial-common:hawthorn.master
     environment:
       - NO_PREREQ_INSTALL: "true"
+      - DJANGO_SETTINGS_MODULE: "lms.envs.test"
     steps:
       - checkout
 
@@ -123,6 +124,7 @@ jobs:
       - image: edxops/xenial-common:hawthorn.master
     environment:
       - NO_PREREQ_INSTALL: "true"
+      - DJANGO_SETTINGS_MODULE: "lms.envs.test"
     steps:
       - checkout
 
@@ -159,6 +161,7 @@ jobs:
       - image: edxops/xenial-common:hawthorn.master
     environment:
       - NO_PREREQ_INSTALL: "true"
+      - DJANGO_SETTINGS_MODULE: "lms.envs.test"
     steps:
       - checkout
 
@@ -187,7 +190,6 @@ jobs:
       - run:
           name: Run tests
           command: |
-            echo $DJANGO_SETTINGS_MODULE
             source /tmp/workspace/venv/bin/activate
             paver test_lib --with-flaky --cov-args="-p" --with-xunitmp
 
@@ -196,6 +198,7 @@ jobs:
       - image: edxops/xenial-common:hawthorn.master
     environment:
       - NO_PREREQ_INSTALL: "true"
+      - DJANGO_SETTINGS_MODULE: "lms.envs.test"
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,42 +119,6 @@ jobs:
             source /tmp/workspace/venv/bin/activate
             paver test_system -s lms --with-flaky --processes=1 --cov-args="-p" --with-xunitmp
 
-  lms_unit_tests_no_env_var:
-    docker:
-      - image: edxops/xenial-common:hawthorn.master
-    environment:
-      - NO_PREREQ_INSTALL: "true"
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v1-{{ checksum ".circleci/config.yml" }}-configuration-{{ checksum "scripts/circle-ci-configuration.sh" }}
-
-      - run:
-          name: Install deb packages
-          command: |
-            ./scripts/circle-ci-configuration.sh
-
-      - attach_workspace:
-          at: /tmp/workspace
-
-      - restore_cache:
-          keys:
-            - v2-{{ checksum ".circleci/config.yml" }}-npm-deps-{{ checksum "package.json" }}
-
-      - run:
-          name: Install local pip packages
-          command: |
-            source /tmp/workspace/venv/bin/activate
-            pip install -r requirements/edx/local.txt
-
-      - run:
-          name: Run tests
-          command: |
-            source /tmp/workspace/venv/bin/activate
-            paver test_system -s lms --with-flaky --processes=1 --cov-args="-p" --with-xunitmp
-
   cms_unit_tests:
     docker:
       - image: edxops/xenial-common:hawthorn.master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+            echo $DJANGO_SETTINGS_MODULE
             source /tmp/workspace/venv/bin/activate
             paver test_lib --with-flaky --cov-args="-p" --with-xunitmp
 


### PR DESCRIPTION
Fix test failures

**Reviewers**

[ ] @pomegranited 
[ ] @itsjeyd 

**Author Notes & Concerns**

I could reproduce similar test failures of #5 and #14 in my devstack when changing the environment variable `DJANGO_SETTINGS_MODULE`. Investigate if it is being passed correctly to the tests before running them.

The environment variable `DJANGO_SETTINGS_MODULE` is not properly being set when running from an external [PR](https://circleci.com/gh/edx-olive-oc/edx-platform/486). Although [`master`](https://circleci.com/gh/edx-olive-oc/edx-platform/492) and branches run ok.

From the CircleCI [docs](https://circleci.com/docs/2.0/env-vars/#overview). It looks like the variable set in #8 doesn't work for external PR's. Therefore I've added it to the `config.yml`. I believe it's fine to remove the variable from the settings and keep it only in `config.yml`, once this is merged. This way we don't get confused in the future.
